### PR TITLE
Use digitalPinToInterrupt on newer versions of Arduino

### DIFF
--- a/lcd_capacitive_multitouch/FT5x06.cpp
+++ b/lcd_capacitive_multitouch/FT5x06.cpp
@@ -68,7 +68,11 @@ BSD license, all text above must be included in any redistribution
     
     // Interrupt
     pinMode(_ctpInt ,INPUT);
+#ifdef digitalPinToInterrupt
+    attachInterrupt(digitalPinToInterrupt(_ctpInt),touch_interrupt,FALLING);
+#else
     attachInterrupt(0,touch_interrupt,FALLING);
+#endif
    
 
     Wire.begin();


### PR DESCRIPTION
Newer versions of Arduino have a #define for digitalPinToInterrupt(), to convert pin numbers to interrupt numbers for attachInterrupt.  This tiny patch will make your code compatible with all future boards, regardless of their pin-to-interrupt mapping, and it will fall back to your original approach when used on older versions of Arduino.
